### PR TITLE
Fix manual item save RLS failure

### DIFF
--- a/src/pages/ScanPage.tsx
+++ b/src/pages/ScanPage.tsx
@@ -212,8 +212,10 @@ export const ScanPage: React.FC = () => {
           error={scanError}
           clearResult={clearRecentScan}
           onSave={(updates) => {
-            if (lastScannedPart) {
-              addItem({ ...lastScannedPart, ...updates });
+            if (lastScannedPart && currentList) {
+              // Include the current list ID when saving manually so RLS policies
+              // that rely on list ownership pass correctly
+              addItem({ ...lastScannedPart, ...updates, list_id: currentList.id });
             }
           }}
         />


### PR DESCRIPTION
## Summary
- ensure manual save to list includes the current list ID

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_687dac00f90083308e3638ea61eca1f7